### PR TITLE
[IncreaseMovementSpeed] Add options for druid shapeshifts and necro vampire

### DIFF
--- a/IncreaseMovementSpeed/mod.js
+++ b/IncreaseMovementSpeed/mod.js
@@ -9,3 +9,15 @@ charstats.rows.forEach((row) => {
   }
 });
 D2RMM.writeTsv(charstatsFilename, charstats);
+
+const monstatsFilename = 'global\\excel\\monstats.txt';
+const monstats = D2RMM.readTsv(monstatsFilename);
+monstats.rows.forEach((row) => {
+  if (row.Id === 'bear' || row.Id === 'wolf') {
+    row.Velocity = config.druidshapeshift;
+  }
+  if (row.Id === 'vampire5') {
+    row.Velocity = row.Run = config.necrovampire;
+  }
+});
+D2RMM.writeTsv(monstatsFilename, monstats);

--- a/IncreaseMovementSpeed/mod.json
+++ b/IncreaseMovementSpeed/mod.json
@@ -3,12 +3,13 @@
   "description": "Increases movement speed of characters.",
   "author": "olegbl",
   "website": "https://www.nexusmods.com/diablo2resurrected/mods/250",
-  "version": "1.0",
+  "version": "1.1",
   "config": [
     {
       "id": "walk",
       "type": "number",
       "name": "Walk Speed",
+      "description": "Vanilla value is 6.",
       "defaultValue": 6,
       "minValue": 1
     },
@@ -16,6 +17,23 @@
       "id": "run",
       "type": "number",
       "name": "Run Speed",
+      "description": "Vanilla value is 9.",
+      "defaultValue": 9,
+      "minValue": 1
+    },
+    {
+      "id": "druidshapeshift",
+      "type": "number",
+      "name": "Werewolf/Werebear Walk Speed",
+      "description": "Vanilla value is 6. Shapeshift run speed equals this value times 1.5.",
+      "defaultValue": 6,
+      "minValue": 1
+    },
+    {
+      "id": "necrovampire",
+      "type": "number",
+      "name": "Necro Vampire Speed",
+      "description": "Vanilla value is 9. Uses same speed for walking and running. Warning: Also affects enemy vampires in Catacombs.",
       "defaultValue": 9,
       "minValue": 1
     }


### PR DESCRIPTION
Druid's shapeshifts and Necromancer's [vampire form](https://diablo.fandom.com/wiki/Trang-Oul%27s_Avatar) are unaffected by the velocity values in charstats.txt. Instead they take their velocity from data in monstats.txt.

This adds additional options for both, with some caveats:
- The shapeshifts can't have walk and run speed adjusted separately. Running uses the same value as walking, but just multiplies it by 1.5.
- The vampire form uses one of the vampire types that spawn in Catacombs, so can't modify the value without affecting both.