### PR TITLE
Add support for bulk gem upgrade

### DIFF
--- a/StackableGems/mod.js
+++ b/StackableGems/mod.js
@@ -202,6 +202,38 @@ else if (
     });
   }
 }
+
+if (config.bulkUpgrade) {
+  for (let i = 0; i < ITEM_TYPES.length; i = i + 1) {
+    // no upgrade for perfect gems
+    if ((i+1) % 5 == 0) {
+      continue;
+    }
+    const itemtype = ITEM_TYPES[i];
+    const stacktype = converItemTypeToStackItemType(itemtype);
+    const upgradedItemtype = ITEM_TYPES[i + 1];
+    const upgradedStacktype = converItemTypeToStackItemType(upgradedItemtype);
+    for (let j = 30; j < config.maxStack; j = j + 1) {
+      cubemain.rows.push({
+        description: `Stack of ${j} ${itemtype} + 1 id scroll -> Stack`
+          + ` of 10 ${upgradedItemtype} + Stack of ${j - 30} ${itemtype} + 1`
+          + ` id scroll`,
+        enabled: 1,
+        version: 0,
+        op: 18, // skip recipe if item's Stat.Accr(param) != value
+        param: 70, // quantity (itemstatcost.txt)
+        value: j, // only execute rule if quantity == j
+        numinputs: 2,
+        'input 1': stacktype,
+        'input 2': 'isc',
+        output: `"${upgradedStacktype},qty=10"`,
+        'output b': j == 30 ? null : `"${stacktype},qty=${j - 30}"`,
+        'output c': 'isc',
+        '*eol': 0,
+      });
+    }
+  }
+}
 D2RMM.writeTsv(cubemainFilename, cubemain);
 
 D2RMM.copyFile(

--- a/StackableGems/mod.json
+++ b/StackableGems/mod.json
@@ -17,9 +17,9 @@
       "type": "number",
       "name": "Maximum Stack Size",
       "description": "The maximum quantity that each stack can have.",
-      "defaultValue": 500,
+      "defaultValue": 256,
       "minValue": 2,
-      "maxValue": 1000
+      "maxValue": 256
     },
     {
       "id": "convertWhenDestacking",

--- a/StackableGems/mod.json
+++ b/StackableGems/mod.json
@@ -27,6 +27,13 @@
       "name": "Convert When Destacking",
       "description": "Enable to have the split off gem automatically convert to a non-stackable variant when splitting a stack. Warning: this adds 15k+ cube recipes which slows down the game's startup.",
       "defaultValue": false
+    },
+    {
+      "id": "bulkUpgrade",
+      "type": "checkbox",
+      "name": "30 to 10 Bulk Upgrade",
+      "description": "Enable to add 30 to 10 bulk upgrade recipes. Warning: this adds 6k+ cube recipes which slows down the game's startup.",
+      "defaultValue": false
     }
   ]
 }

--- a/StackableRunes/mod.json
+++ b/StackableRunes/mod.json
@@ -17,9 +17,9 @@
       "type": "number",
       "name": "Maximum Stack Size",
       "description": "The maximum quantity that each stack can have.",
-      "defaultValue": 500,
+      "defaultValue": 256,
       "minValue": 2,
-      "maxValue": 1000
+      "maxValue": 256
     },
     {
       "id": "usenewsprites",


### PR DESCRIPTION
Hi olegbl, I first want to say thank you for d2rmm! It's an amazing mod manager that really helps with the longevity of d2r.

I see this PR has been quite stale: https://github.com/olegbl/d2rmm.mods/pull/1, so I'm giving it another shot to add support for bulk upgrading gems.

I am aware that [Stackit](https://www.nexusmods.com/diablo2resurrected/mods/259) exists, however it's stack size (which is non configurable) is too small for my liking, plus converting my existing stacks to Stackit stacks will take some work.

I'm not adding rune upgrade support in this PR since it has some complications with gem requirements, and conflict with other mods such as [rune easy upgrade](https://www.nexusmods.com/diablo2resurrected/mods/217).

I'm proposing two changes with this PR:

1. Change default and max stack size to 256 (from 500 and 1000).
2. Add cube recipe to bulk upgrade gems 30 -> 10.

### 1. Changing stack size

I believe this is a bug in the way cube recipes are read, but essentially the `qty` caps out as 8 bit unsigned int (i.e. 255). E.g. `qty=400` will be treated as `qty=143` (400 - 257). This means if you have a stack with more than 256 items, you will not be able to unstack it correctly.

You can test this out by purchasing a full stack of arrows (500) and try to unstack it. The expected outcome would be a stack of 499 arrows + a stack of 1 arrow, but actual outcome is a stack of 243 arrows (500 - 257) + a stack of 1 arrow.

I feel it's kinda dangerous to leave default value at 500, since effectively any stacks with more than 256 items will lose 256 items. There is no way to unstack it without resorting to the editor.

The actual max stack size that can be unstacked is 256. Making this change also means we only need roughly half of the recipes for convert on unstack, and bulk upgrade.

### 2. Adding bulk upgrade recipe

To avoid having a blow up in number of recipes, I only added 30 -> 10 upgrade recipes (any stack with more than 30 items can be used).
I'm using id scroll as a guard to avoid misclicking.
This adds ~6.3k recipes so I'm putting it behind a config flag. However during testing I did not feel any noticeable slowdowns to install mod or game startup.