### PR TITLE
CustomItemColors: added Custom color option and RuneColor select

### DIFF
--- a/CustomItemColors/mod.js
+++ b/CustomItemColors/mod.js
@@ -26,6 +26,7 @@ const COLORS = {
   VeryLightGray: '$FontColorVeryLightGray',
   White: '$FontColorWhite',
   Yellow: '$FontColorYellow',
+  Custom: 'Custom'
 };
 
 const VARIABLES = [
@@ -40,11 +41,16 @@ const VARIABLES = [
   'TemperedColor',
   'QuestColor',
   'GoldColor',
+  'RuneColor',
 ];
 
 function changeProfileColors(profile) {
   VARIABLES.forEach((variable) => {
-    const color = COLORS[config[variable]];
+    let color = COLORS[config[variable]];
+    if (color === 'Custom')
+      // Alpha channel not works in font color
+      color = [config.CustomColorR, config.CustomColorG, config.CustomColorB, 1];
+
     if (color != null) {
       profile.TooltipStyle[variable] = color;
     }

--- a/CustomItemColors/mod.json
+++ b/CustomItemColors/mod.json
@@ -6,6 +6,24 @@
   "version": "1.1",
   "config": [
     {
+      "id": "CustomColorR",
+      "type": "number",
+      "name": "Custom Color [Red] (0..255)",
+      "defaultValue": 0
+    },
+    {
+      "id": "CustomColorG",
+      "type": "number",
+      "name": "Custom Color [Green] (0..255)",
+      "defaultValue": 0
+    },
+    {
+      "id": "CustomColorB",
+      "type": "number",
+      "name": "Custom Color [Blue] (0..255)",
+      "defaultValue": 0
+    },
+    {
       "id": "DefaultColor",
       "type": "select",
       "name": "Default Color",
@@ -37,7 +55,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White", "description": "Game Default" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -76,7 +95,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -111,7 +131,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -146,7 +167,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -181,7 +203,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow", "description": "Game Default" }
+        { "value": "Yellow", "label": "Yellow", "description": "Game Default" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -216,7 +239,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -255,7 +279,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -290,7 +315,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -329,7 +355,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -368,7 +395,8 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     },
     {
@@ -403,7 +431,44 @@
         { "value": "Transparent", "label": "Transparent" },
         { "value": "VeryLightGray", "label": "Very Light Gray" },
         { "value": "White", "label": "White", "description": "Game Default" },
-        { "value": "Yellow", "label": "Yellow" }
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
+      ]
+    },
+    {
+      "id": "RuneColor",
+      "type": "select",
+      "name": "Rune Color",
+      "defaultValue": "Orange",
+      "options": [
+        { "value": "Beige", "label": "Beige" },
+        { "value": "Black", "label": "Black" },
+        { "value": "Blue", "label": "Blue" },
+        { "value": "CurrencyGold", "label": "Currency Gold" },
+        { "value": "DarkGold", "label": "Dark Gold" },
+        { "value": "DarkGrayBlue", "label": "Dark Gray Blue" },
+        { "value": "DarkGrayGold", "label": "Dark Gray Gold" },
+        { "value": "DarkGreen", "label": "Dark Green" },
+        { "value": "Gold", "label": "Gold" },
+        { "value": "GoldYellow", "label": "Gold Yellow" },
+        { "value": "Gray", "label": "Gray" },
+        { "value": "Green", "label": "Green" },
+        { "value": "LightBlue", "label": "Light Blue" },
+        { "value": "LightGold", "label": "Light Gold" },
+        { "value": "LightGray", "label": "Light Gray" },
+        { "value": "LightPurple", "label": "Light Purple" },
+        { "value": "LightRed", "label": "Light Red" },
+        { "value": "LightTeal", "label": "Light Teal" },
+        { "value": "LightYellow", "label": "Light Yellow" },
+        { "value": "Orange", "label": "Orange", "description": "Game Default" },
+        { "value": "PartyGreen", "label": "Party Green" },
+        { "value": "PartyOrange", "label": "Party Orange" },
+        { "value": "Red", "label": "Red" },
+        { "value": "Transparent", "label": "Transparent" },
+        { "value": "VeryLightGray", "label": "Very Light Gray" },
+        { "value": "White", "label": "White" },
+        { "value": "Yellow", "label": "Yellow" },
+        { "value": "Custom", "label": "Custom color" }
       ]
     }
   ]


### PR DESCRIPTION
Another clarification of the CustomItemColor mod only changes the color of the tooltip, that is, the item on the ground, but not in the inventory.

In _profilehd.json it is possible to specify only 'RuneColor' without dividing into levels:
![image](https://github.com/olegbl/d2rmm.mods/assets/1458178/21d3442e-a0e9-40b1-acf3-c093dbd61f03)

Custom color selected for Gold (or other) for example:
![image](https://github.com/olegbl/d2rmm.mods/assets/1458178/7623ffd6-7e96-46f0-a412-c16c07da4c61)
![image](https://github.com/olegbl/d2rmm.mods/assets/1458178/df99d576-347b-4a3c-80a8-a2f2ea1df843)
