### PR TITLE
[ExpandedStash] Added custom stash tab names option

### DIFF
--- a/ExpandedStash/mod.js
+++ b/ExpandedStash/mod.js
@@ -3,14 +3,18 @@ if (D2RMM.getVersion == null || D2RMM.getVersion() < 1.6) {
   return;
 }
 
-const tabNamePersonal = (!config.IsCustomTabNamesEnabled || config.tabNamePersonal === "") ? "@personal" : config.tabNamePersonal;
-const tabNameShared1  = (!config.IsCustomTabNamesEnabled || config.tabNameShared1  === "") ? "@shared"   : config.tabNameShared1;
-const tabNameShared2  = (!config.IsCustomTabNamesEnabled || config.tabNameShared2  === "") ? "@shared"   : config.tabNameShared2;
-const tabNameShared3  = (!config.IsCustomTabNamesEnabled || config.tabNameShared3  === "") ? "@shared"   : config.tabNameShared3;
-const tabNameShared4  = (!config.IsCustomTabNamesEnabled || config.tabNameShared4  === "") ? "@shared"   : config.tabNameShared4;
-const tabNameShared5  = (!config.IsCustomTabNamesEnabled || config.tabNameShared5  === "") ? "@shared"   : config.tabNameShared5;
-const tabNameShared6  = (!config.IsCustomTabNamesEnabled || config.tabNameShared6  === "") ? "@shared"   : config.tabNameShared6;
-const tabNameShared7  = (!config.IsCustomTabNamesEnabled || config.tabNameShared7  === "") ? "@shared"   : config.tabNameShared7;
+function setTabName(setName, defaultName) {
+  return !config.isCustomTabsEnabled || setName === '' ? defaultName : setName;
+}
+
+const tabNamePersonal = setTabName(config.tabNamePersonal, '@personal');
+const tabNameShared1 = setTabName(config.tabNameShared1, '@shared');
+const tabNameShared2 = setTabName(config.tabNameShared2, '@shared');
+const tabNameShared3 = setTabName(config.tabNameShared3, '@shared');
+const tabNameShared4 = setTabName(config.tabNameShared4, '@shared');
+const tabNameShared5 = setTabName(config.tabNameShared5, '@shared');
+const tabNameShared6 = setTabName(config.tabNameShared6, '@shared');
+const tabNameShared7 = setTabName(config.tabNameShared7, '@shared');
 
 const inventoryFilename = 'global\\excel\\inventory.txt';
 const inventory = D2RMM.readTsv(inventoryFilename);

--- a/ExpandedStash/mod.js
+++ b/ExpandedStash/mod.js
@@ -3,6 +3,15 @@ if (D2RMM.getVersion == null || D2RMM.getVersion() < 1.6) {
   return;
 }
 
+const tabNamePersonal = (!config.IsCustomTabNamesEnabled || config.tabNamePersonal === "") ? "@personal" : config.tabNamePersonal;
+const tabNameShared1  = (!config.IsCustomTabNamesEnabled || config.tabNameShared1  === "") ? "@shared"   : config.tabNameShared1;
+const tabNameShared2  = (!config.IsCustomTabNamesEnabled || config.tabNameShared2  === "") ? "@shared"   : config.tabNameShared2;
+const tabNameShared3  = (!config.IsCustomTabNamesEnabled || config.tabNameShared3  === "") ? "@shared"   : config.tabNameShared3;
+const tabNameShared4  = (!config.IsCustomTabNamesEnabled || config.tabNameShared4  === "") ? "@shared"   : config.tabNameShared4;
+const tabNameShared5  = (!config.IsCustomTabNamesEnabled || config.tabNameShared5  === "") ? "@shared"   : config.tabNameShared5;
+const tabNameShared6  = (!config.IsCustomTabNamesEnabled || config.tabNameShared6  === "") ? "@shared"   : config.tabNameShared6;
+const tabNameShared7  = (!config.IsCustomTabNamesEnabled || config.tabNameShared7  === "") ? "@shared"   : config.tabNameShared7;
+
 const inventoryFilename = 'global\\excel\\inventory.txt';
 const inventory = D2RMM.readTsv(inventoryFilename);
 inventory.rows.forEach((row) => {
@@ -78,14 +87,14 @@ bankExpansionLayout.children = bankExpansionLayout.children.map((child) => {
   if (child.name === 'BankTabs') {
     child.fields.tabCount = 8;
     child.fields.textStrings = [
-      '@personal',
-      '@shared',
-      '@shared',
-      '@shared',
-      '@shared',
-      '@shared',
-      '@shared',
-      '@shared',
+      tabNamePersonal,
+      tabNameShared1,
+      tabNameShared2,
+      tabNameShared3,
+      tabNameShared4,
+      tabNameShared5,
+      tabNameShared6,
+      tabNameShared7,
     ];
   }
   return true;
@@ -164,14 +173,14 @@ bankExpansionLayoutHD.children = bankExpansionLayoutHD.children.filter(
       child.fields.activeFrames = [1, 1, 1, 1, 1, 1, 1, 1];
       child.fields.disabledFrames = [0, 0, 0, 0, 0, 0, 0, 0];
       child.fields.textStrings = [
-        '@personal',
-        '@shared',
-        '@shared',
-        '@shared',
-        '@shared',
-        '@shared',
-        '@shared',
-        '@shared',
+        tabNamePersonal,
+        tabNameShared1,
+        tabNameShared2,
+        tabNameShared3,
+        tabNameShared4,
+        tabNameShared5,
+        tabNameShared6,
+        tabNameShared7,
       ];
     }
     if (child.name === 'gold_amount') {
@@ -286,14 +295,14 @@ bankExpansionControllerLayoutHD.children =
       child.fields.activeFrames = [0, 0, 0, 0, 0, 0, 0, 0];
       child.fields.disabledFrames = [1, 1, 1, 1, 1, 1, 1, 1];
       child.fields.textStrings = [
-        '@personal',
-        '@shared',
-        '@shared',
-        '@shared',
-        '@shared',
-        '@shared',
-        '@shared',
-        '@shared',
+        tabNamePersonal,
+        tabNameShared1,
+        tabNameShared2,
+        tabNameShared3,
+        tabNameShared4,
+        tabNameShared5,
+        tabNameShared6,
+        tabNameShared7,
       ];
       child.fields.tabLeftIndicatorPosition = { x: -42, y: -2 };
       child.fields.tabRightIndicatorPosition = { x: 1135 + 300, y: -2 };

--- a/ExpandedStash/mod.json
+++ b/ExpandedStash/mod.json
@@ -3,6 +3,71 @@
   "description": "Increases stash size to 16x13. Based on https://www.nexusmods.com/diablo2resurrected/mods/13.",
   "author": "olegbl",
   "website": "https://www.nexusmods.com/diablo2resurrected/mods/173",
-  "version": "1.5"
+  "version": "1.6",
+  "config": [
+    {
+      "id": "IsCustomTabNamesEnabled",
+      "type": "checkbox",
+      "name": "Enable Custom Tab Names",
+      "description": "Enable the custom stash tab names set below.",
+      "defaultValue": true
+    },
+    {
+      "id": "tabNamePersonal",
+      "type": "text",
+      "name": "Personal Tab",
+      "description": "Set a custom name for the Personal stash tab. Leave blank to use the default name.",
+      "defaultValue": ""
+    },
+    {
+      "id": "tabNameShared1",
+      "type": "text",
+      "name": "Shared Tab 1",
+      "description": "Set a custom name for the first Shared stash tab. Leave blank to use the default name.",
+      "defaultValue": ""
+    },
+    {
+      "id": "tabNameShared2",
+      "type": "text",
+      "name": "Shared Tab 2",
+      "description": "Set a custom name for the second Shared stash tab. Leave blank to use the default name.",
+      "defaultValue": ""
+    },
+    {
+      "id": "tabNameShared3",
+      "type": "text",
+      "name": "Shared Tab 3",
+      "description": "Set a custom name for the third Shared stash tab. Leave blank to use the default name.",
+      "defaultValue": ""
+    },
+    {
+      "id": "tabNameShared4",
+      "type": "text",
+      "name": "Shared Tab 4",
+      "description": "Set a custom name for the fourth Shared stash tab. Leave blank to use the default name.",
+      "defaultValue": ""
+    },
+    {
+      "id": "tabNameShared5",
+      "type": "text",
+      "name": "Shared Tab 5",
+      "description": "Set a custom name for the fifth Shared stash tab. Leave blank to use the default name.",
+      "defaultValue": ""
+    },
+    {
+      "id": "tabNameShared6",
+      "type": "text",
+      "name": "Shared Tab 6",
+      "description": "Set a custom name for the sixth Shared stash tab. Leave blank to use the default name.",
+      "defaultValue": ""
+    },
+    {
+      "id": "tabNameShared7",
+      "type": "text",
+      "name": "Shared Tab 7",
+      "description": "Set a custom name for the seventh Shared stash tab. Leave blank to use the default name.",
+      "defaultValue": ""
+    }
+  ]
 }
 

--- a/ExpandedStash/mod.json
+++ b/ExpandedStash/mod.json
@@ -9,64 +9,72 @@
       "id": "IsCustomTabNamesEnabled",
       "type": "checkbox",
       "name": "Enable Custom Tab Names",
-      "description": "Enable the custom stash tab names set below.",
-      "defaultValue": true
+      "description": "Set a custom name for each stash tab using the fields below.",
+      "defaultValue": false
     },
     {
       "id": "tabNamePersonal",
       "type": "text",
       "name": "Personal Tab",
       "description": "Set a custom name for the Personal stash tab. Leave blank to use the default name.",
-      "defaultValue": ""
+      "defaultValue": "",
+      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
     },
     {
       "id": "tabNameShared1",
       "type": "text",
       "name": "Shared Tab 1",
       "description": "Set a custom name for the first Shared stash tab. Leave blank to use the default name.",
-      "defaultValue": ""
+      "defaultValue": "",
+      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
     },
     {
       "id": "tabNameShared2",
       "type": "text",
       "name": "Shared Tab 2",
       "description": "Set a custom name for the second Shared stash tab. Leave blank to use the default name.",
-      "defaultValue": ""
+      "defaultValue": "",
+      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
     },
     {
       "id": "tabNameShared3",
       "type": "text",
       "name": "Shared Tab 3",
       "description": "Set a custom name for the third Shared stash tab. Leave blank to use the default name.",
-      "defaultValue": ""
+      "defaultValue": "",
+      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
     },
     {
       "id": "tabNameShared4",
       "type": "text",
       "name": "Shared Tab 4",
       "description": "Set a custom name for the fourth Shared stash tab. Leave blank to use the default name.",
-      "defaultValue": ""
+      "defaultValue": "",
+      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
     },
     {
       "id": "tabNameShared5",
       "type": "text",
       "name": "Shared Tab 5",
       "description": "Set a custom name for the fifth Shared stash tab. Leave blank to use the default name.",
-      "defaultValue": ""
+      "defaultValue": "",
+      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
     },
     {
       "id": "tabNameShared6",
       "type": "text",
       "name": "Shared Tab 6",
       "description": "Set a custom name for the sixth Shared stash tab. Leave blank to use the default name.",
-      "defaultValue": ""
+      "defaultValue": "",
+      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
     },
     {
       "id": "tabNameShared7",
       "type": "text",
       "name": "Shared Tab 7",
       "description": "Set a custom name for the seventh Shared stash tab. Leave blank to use the default name.",
-      "defaultValue": ""
+      "defaultValue": "",
+      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
     }
   ]
 }

--- a/ExpandedStash/mod.json
+++ b/ExpandedStash/mod.json
@@ -18,7 +18,7 @@
       "name": "Personal Tab",
       "description": "Set a custom name for the Personal stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["value", "IsCustomTabNamesEnabled"]
+      "visible": ["value", "isCustomTabsEnabled"]
     },
     {
       "id": "tabNameShared1",
@@ -26,7 +26,7 @@
       "name": "Shared Tab 1",
       "description": "Set a custom name for the first Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["value", "IsCustomTabNamesEnabled"]
+      "visible": ["value", "isCustomTabsEnabled"]
     },
     {
       "id": "tabNameShared2",
@@ -34,7 +34,7 @@
       "name": "Shared Tab 2",
       "description": "Set a custom name for the second Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["value", "IsCustomTabNamesEnabled"]
+      "visible": ["value", "isCustomTabsEnabled"]
     },
     {
       "id": "tabNameShared3",
@@ -42,7 +42,7 @@
       "name": "Shared Tab 3",
       "description": "Set a custom name for the third Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["value", "IsCustomTabNamesEnabled"]
+      "visible": ["value", "isCustomTabsEnabled"]
     },
     {
       "id": "tabNameShared4",
@@ -50,7 +50,7 @@
       "name": "Shared Tab 4",
       "description": "Set a custom name for the fourth Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["value", "IsCustomTabNamesEnabled"]
+      "visible": ["value", "isCustomTabsEnabled"]
     },
     {
       "id": "tabNameShared5",
@@ -58,7 +58,7 @@
       "name": "Shared Tab 5",
       "description": "Set a custom name for the fifth Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["value", "IsCustomTabNamesEnabled"]
+      "visible": ["value", "isCustomTabsEnabled"]
     },
     {
       "id": "tabNameShared6",
@@ -66,7 +66,7 @@
       "name": "Shared Tab 6",
       "description": "Set a custom name for the sixth Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["value", "IsCustomTabNamesEnabled"]
+      "visible": ["value", "isCustomTabsEnabled"]
     },
     {
       "id": "tabNameShared7",
@@ -74,7 +74,7 @@
       "name": "Shared Tab 7",
       "description": "Set a custom name for the seventh Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["value", "IsCustomTabNamesEnabled"]
+      "visible": ["value", "isCustomTabsEnabled"]
     }
   ]
 }

--- a/ExpandedStash/mod.json
+++ b/ExpandedStash/mod.json
@@ -6,7 +6,7 @@
   "version": "1.6",
   "config": [
     {
-      "id": "IsCustomTabNamesEnabled",
+      "id": "isCustomTabsEnabled",
       "type": "checkbox",
       "name": "Enable Custom Tab Names",
       "description": "Set a custom name for each stash tab using the fields below.",
@@ -18,7 +18,7 @@
       "name": "Personal Tab",
       "description": "Set a custom name for the Personal stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
+      "visible": ["value", "IsCustomTabNamesEnabled"]
     },
     {
       "id": "tabNameShared1",
@@ -26,7 +26,7 @@
       "name": "Shared Tab 1",
       "description": "Set a custom name for the first Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
+      "visible": ["value", "IsCustomTabNamesEnabled"]
     },
     {
       "id": "tabNameShared2",
@@ -34,7 +34,7 @@
       "name": "Shared Tab 2",
       "description": "Set a custom name for the second Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
+      "visible": ["value", "IsCustomTabNamesEnabled"]
     },
     {
       "id": "tabNameShared3",
@@ -42,7 +42,7 @@
       "name": "Shared Tab 3",
       "description": "Set a custom name for the third Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
+      "visible": ["value", "IsCustomTabNamesEnabled"]
     },
     {
       "id": "tabNameShared4",
@@ -50,7 +50,7 @@
       "name": "Shared Tab 4",
       "description": "Set a custom name for the fourth Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
+      "visible": ["value", "IsCustomTabNamesEnabled"]
     },
     {
       "id": "tabNameShared5",
@@ -58,7 +58,7 @@
       "name": "Shared Tab 5",
       "description": "Set a custom name for the fifth Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
+      "visible": ["value", "IsCustomTabNamesEnabled"]
     },
     {
       "id": "tabNameShared6",
@@ -66,7 +66,7 @@
       "name": "Shared Tab 6",
       "description": "Set a custom name for the sixth Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
+      "visible": ["value", "IsCustomTabNamesEnabled"]
     },
     {
       "id": "tabNameShared7",
@@ -74,7 +74,7 @@
       "name": "Shared Tab 7",
       "description": "Set a custom name for the seventh Shared stash tab. Leave blank to use the default name.",
       "defaultValue": "",
-      "visible": ["eq", ["value", "IsCustomTabNamesEnabled"], true]
+      "visible": ["value", "IsCustomTabNamesEnabled"]
     }
   ]
 }


### PR DESCRIPTION
Adds settings to the ExpandedStash mod to rename the stash tabs to whatever you'd like:
- a master switch to enable/disable all names set below
- 7 text fields for each stash tab from left to right
- text fields will be hidden if master switch is set to disabled, using the new D2RMM 1.6.0 `visible` feature